### PR TITLE
chore(k8s-notify): Update docs to build & migrate base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM centos:7
+FROM alpine:3.10
+
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 ENV OPERATOR=/usr/local/bin/k8s-notify \
     USER_UID=1001 \

--- a/README.adoc
+++ b/README.adoc
@@ -100,6 +100,15 @@ image::/docs/images/pod-created.png[]
 
 We got a message!
 
+== Building the docker image
+
+Run the following command to build the binary:
+
+```
+env GOOS=linux GOARCH=386 go build -o "build/_output/bin/k8s-notify" ./cmd/manager
+docker build . -t <tag>
+```
+
 == Contributing
 
 We welcome contributions from the community. Feel free to link:https://github.com/etsauer/k8s-notify/issues/new[open issues] and link:https://github.com/etsauer/k8s-notify/pulls/new[pull requests].


### PR DESCRIPTION
- Fork the repo and change the base docker image from `centos` to `apline` because
  --- Alpine is smaller : we pay less for data transfer
  --- Alpine is faster : we will need less resources to run this
  --- Alpine is secure : 🤷‍♂ 
- Also added some documentation.